### PR TITLE
Add onTemplateCreated event for TPresenter

### DIFF
--- a/src/Traits/TPresenter.php
+++ b/src/Traits/TPresenter.php
@@ -9,6 +9,8 @@ trait TPresenter {
 	/** @var WebChemistry\Images\Storage */
 	public $imageStorage;
 
+    public $onTemplateCreated = array();
+
 	/**
 	 * @param WebChemistry\Images\Storage $storage
 	 */
@@ -20,6 +22,8 @@ trait TPresenter {
 		$template = parent::createTemplate();
 
 		$template->imageStorage = $this->imageStorage;
+
+        $this->onTemplateCreated($template);
 
 		return $template;
 	}


### PR DESCRIPTION
This is useful if some additional operations with template are necessary. Without
this, it is impossible for presenter with this trait to affect template creation
(implementing createTemplate() in presenter itself would override trait's method,
therefore storage wouldn't be injected).
