### PR TITLE
aliases create empty directories

### DIFF
--- a/src/Storages/LocalStorage.php
+++ b/src/Storages/LocalStorage.php
@@ -100,8 +100,8 @@ class LocalStorage extends Storage {
 			return FALSE;
 		}
 		$image = $this->imageFactory->createFromFile($originalPath);
-		$this->makeDir($path);
 		$this->modifierContainer->modifyImage($resource, $image);
+		$this->makeDir($path);
 		$image->save($path);
 
 		return $location;


### PR DESCRIPTION
empty directory was created when you use a alias which wasn't defined