### PR TITLE
Catch Nette/Image exception

### DIFF
--- a/src/Storages/LocalStorage.php
+++ b/src/Storages/LocalStorage.php
@@ -170,6 +170,8 @@ class LocalStorage extends Storage {
 				$image = $this->imageFactory->createFromFile($originalPath);
 			} catch (UnknownImageFileException $e) {
 				return null;
+			} catch (ImageException $e){
+				return null;
 			}
 		} else {
 			throw new ImageStorageException('Resource must be instance of ITransferResource or IFileResource.');


### PR DESCRIPTION
If Nette image was unable to create image, for example due to GD exception, ImageException is thrown.